### PR TITLE
Classkit license support

### DIFF
--- a/demos/create_capacitor.py
+++ b/demos/create_capacitor.py
@@ -6,8 +6,15 @@ and falls back to the Java layer when functionality is (still) missing.
 """
 __license__ = 'MIT'
 
-
+import sys
+import logging
 import mph
+
+if 'log' in sys.argv[1:]:
+    logging.basicConfig(level=logging.DEBUG)
+
+if 'classkit' in sys.argv[1:]:
+    mph.option('classkit', True)
 
 client = mph.start()
 model = client.create('capacitor')

--- a/demos/create_capacitor.py
+++ b/demos/create_capacitor.py
@@ -7,11 +7,7 @@ and falls back to the Java layer when functionality is (still) missing.
 __license__ = 'MIT'
 
 import sys
-import logging
 import mph
-
-if 'log' in sys.argv[1:]:
-    logging.basicConfig(level=logging.DEBUG)
 
 if 'classkit' in sys.argv[1:]:
     mph.option('classkit', True)

--- a/demos/create_capacitor.py
+++ b/demos/create_capacitor.py
@@ -6,11 +6,7 @@ and falls back to the Java layer when functionality is (still) missing.
 """
 __license__ = 'MIT'
 
-import sys
 import mph
-
-if 'classkit' in sys.argv[1:]:
-    mph.option('classkit', True)
 
 client = mph.start()
 model = client.create('capacitor')

--- a/demos/create_capacitor.py
+++ b/demos/create_capacitor.py
@@ -6,6 +6,7 @@ and falls back to the Java layer when functionality is (still) missing.
 """
 __license__ = 'MIT'
 
+
 import mph
 
 client = mph.start()

--- a/mph/client.py
+++ b/mph/client.py
@@ -81,6 +81,12 @@ class Client:
     ####################################
 
     def __init__(self, cores=None, version=None, port=None, host='localhost'):
+        # Check if this will work with classkit, check so early to prevent
+        # unnneccessary jpype start
+        if port is None and option('classkit-license'):
+            error = 'Classkit license does not support API in standalone mode.'
+            logger.error(error)
+            raise NotImplementedError(error)
 
         # Make sure this is the one and only client.
         if jpype.isJVMStarted():

--- a/mph/client.py
+++ b/mph/client.py
@@ -107,7 +107,7 @@ class Client:
         logger.info('Starting Java virtual machine.')
         java_args = [str(backend['jvm'])]
         if option('classkit'):
-            java_args += ['-Dckl']
+            java_args += ['-Dcs.ckl']
         logger.debug(f'JVM arguments: {java_args}')
         jpype.startJVM(*java_args,
                        classpath=str(backend['root']/'plugins'/'*'),

--- a/mph/client.py
+++ b/mph/client.py
@@ -141,9 +141,10 @@ class Client:
         java.setPreference('tempfiles.saving.warnifoverwriteolder', 'off')
         java.setPreference('tempfiles.recovery.autosave', 'off')
         try:
+            # Preference not defined on certain systems, see issue #39.
             java.setPreference('tempfiles.recovery.checkforrecoveries', 'off')
         except Exception:
-            logger.warning('Could not turn off check for recovery files.')
+            logger.debug('Could not turn off check for recovery files.')
         java.setPreference('tempfiles.saving.optimize', 'filesize')
 
         # Save useful information in instance attributes.

--- a/mph/config.py
+++ b/mph/config.py
@@ -9,7 +9,7 @@ __license__ = 'MIT'
 options = {
     'session': 'platform-dependent',
     'caching': False,
-    'classkit-license': False,
+    'classkit': False,
 }
 """Default values for configuration options."""
 

--- a/mph/config.py
+++ b/mph/config.py
@@ -9,6 +9,7 @@ __license__ = 'MIT'
 options = {
     'session': 'platform-dependent',
     'caching': False,
+    'classkit-license': False,
 }
 """Default values for configuration options."""
 

--- a/mph/server.py
+++ b/mph/server.py
@@ -6,7 +6,7 @@ __license__ = 'MIT'
 # Components                           #
 ########################################
 from . import discovery                # back-end discovery
-from .config import option
+from .config import option             # configuration
 
 
 ########################################

--- a/mph/server.py
+++ b/mph/server.py
@@ -6,6 +6,7 @@ __license__ = 'MIT'
 # Components                           #
 ########################################
 from . import discovery                # back-end discovery
+from .config import option
 
 
 ########################################
@@ -75,6 +76,8 @@ class Server:
         server  = backend['server']
         logger.info('Starting external server process.')
         arguments = ['-login', 'auto', '-graphics']
+        if option('classkit-license'):
+            arguments += ['-ckl']
         if cores:
             arguments += ['-np', str(cores)]
             noun = 'core' if cores == 1 else 'cores'

--- a/mph/server.py
+++ b/mph/server.py
@@ -76,7 +76,7 @@ class Server:
         server  = backend['server']
         logger.info('Starting external server process.')
         arguments = ['-login', 'auto', '-graphics']
-        if option('classkit-license'):
+        if option('classkit'):
             arguments += ['-ckl']
         if cores:
             arguments += ['-np', str(cores)]

--- a/mph/session.py
+++ b/mph/session.py
@@ -92,9 +92,18 @@ def start(cores=None, version=None, port=0):
         return client
 
     session = option('session')
+
+    if option('classkit-license') and session == 'stand-alone':
+        error = 'Classkit license does not support API in standalone mode.'
+        logger.error(error)
+        raise NotImplementedError(error)
+
     if session == 'platform-dependent':
         if platform.system() == 'Windows':
-            session = 'stand-alone'
+            if option('classkit-license'):
+                session = 'client-server'
+            else:
+                session = 'stand-alone'
         else:
             session = 'client-server'
 

--- a/mph/session.py
+++ b/mph/session.py
@@ -92,7 +92,6 @@ def start(cores=None, version=None, port=0):
         return client
 
     session = option('session')
-
     if session == 'platform-dependent':
         if platform.system() == 'Windows':
             session = 'stand-alone'

--- a/mph/session.py
+++ b/mph/session.py
@@ -93,17 +93,14 @@ def start(cores=None, version=None, port=0):
 
     session = option('session')
 
-    if option('classkit-license') and session == 'stand-alone':
+    if option('classkit') and session == 'stand-alone':
         error = 'Classkit license does not support API in standalone mode.'
         logger.error(error)
         raise NotImplementedError(error)
 
     if session == 'platform-dependent':
         if platform.system() == 'Windows':
-            if option('classkit-license'):
-                session = 'client-server'
-            else:
-                session = 'stand-alone'
+            session = 'stand-alone'
         else:
             session = 'client-server'
 

--- a/mph/session.py
+++ b/mph/session.py
@@ -93,11 +93,6 @@ def start(cores=None, version=None, port=0):
 
     session = option('session')
 
-    if option('classkit') and session == 'stand-alone':
-        error = 'Classkit license does not support API in standalone mode.'
-        logger.error(error)
-        raise NotImplementedError(error)
-
     if session == 'platform-dependent':
         if platform.system() == 'Windows':
             session = 'stand-alone'


### PR DESCRIPTION
I opened this PR to stop cluttering chat - again my *solution* is obviously WiP. The initial discussion pulled from chat is

> On another note: You can take a look at …
> 
> There's a special student "classkit" license.
> The server call accepts -ckl to choose this license
> It will not work with standalone since there seems to be no option to start that using the option (at least i found nothing in > the docs)
> COMSOL is dumb and not aware of available licenses, thus not using -ckl with only classkit licenses available yields a licence error on client.load() as does the way around, e.g. using classkit with a real license

I currently have someone running from this commit and will report back if it works.

Regarding your remarks:

>  a Comsol installation on Windows would have a file named …

Sadly, can **not** confirm. Neither for classkit nor for full installations. I wonder what’s the difference anyway. I can change license server and shortcut and then it works on windows. On Unix, I cannot really see a difference since there is not real *shortcut* so switching back and forth is possible. Also, with a classkit installation, the exe only has `"C:\Program Files\COMSOL\COMSOL54\Multiphysics\bin\win64\comsol.exe" -Dcs.ckl`, missing the additional line as stated in the docs. I also checked that against the `5.4` and `5.5` Installation guide - same story. So from the installation we have here, using the file does not seem to be an option. I don’t know if this has to do with the centralized license server build, however I do not see this being a stable solution and the central license server should be quite common in larger ecosystems.

> Also, for Windows it says the command-line argument is `-Dcs.ckl`

True. It also seems to accept `-ckl`. My experience with java is too little to follow you why you would assume that the above is a java argument. If it is we should enable stand-alone with the argument above on windows. I can test that here.