### PR TITLE
lockfile check on load() and new load_copy function

### DIFF
--- a/mph/client.py
+++ b/mph/client.py
@@ -319,7 +319,7 @@ class Client:
         if self.caching() and file in self.files():
             log.info(f'Retrieving "{file.name}" from cache.')
             return self.models()[self.files().index(file)]
-        lock_file = file.with_suffix('.lock')
+        lock_file = Path(str(file) + '.lock')
         if lock_file.exists():
             log.warning(f'Model already opened by "{lock_file.read_text().strip()}"')
             return None

--- a/mph/client.py
+++ b/mph/client.py
@@ -319,9 +319,25 @@ class Client:
         if self.caching() and file in self.files():
             log.info(f'Retrieving "{file.name}" from cache.')
             return self.models()[self.files().index(file)]
+        lock_file = file.with_suffix('.lock')
+        if lock_file.exists():
+            log.warning(f'Model already opened by "{lock_file.read_text().strip()}"')
+            return None
         tag = self.java.uniquetag('model')
         log.info(f'Loading model "{file.name}".')
         model = Model(self.java.load(tag, str(file)))
+        log.info('Finished loading model.')
+        return model
+
+    def load_copy(self, file):
+        """Loads a copy (read only) of model from the given `file` and returns it."""
+        file = Path(file).resolve()
+        if self.caching() and file in self.files():
+            log.info(f'Retrieving "{file.name}" from cache.')
+            return self.models()[self.files().index(file)]
+        tag = self.java.uniquetag('model')
+        log.info(f'Loading model "{file.name}".')
+        model = Model(self.java.loadCopy(tag, str(file)))
         log.info('Finished loading model.')
         return model
 


### PR DESCRIPTION
on Linux the server does not fail to load when there is also lying a `.lock` next to the mph file. This can lead to complete failure and data loss when saving the model when working on samba mounts (windows shared drives).

This PR adds check on the load function for a local `.lock` file with no loading and a log.warning(). This PR also adds a load_copy() function, similar to the "read only" functionality in COMSOL ui.

I think it is best to keep those two functions apart to ensure that scrip/user always take an active choice on how to work on the model file.