### PR TITLE
Include Comsol installation found on `PATH` in discovery

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,31 +1,39 @@
 ﻿# Installation
 
-MPh is [available on PyPI][pypi] and can be readily installed via
-```none
+MPh is [available on PyPI] and can be readily installed via
+```
 pip install MPh
 ```
-Run `pip uninstall MPh` in order to remove the package from your system.
 
-Requires [JPype][jpype] for the bridge from Python to [Comsol's
-Java API][japi] and [NumPy][numpy] for returning (fast) numerical arrays.
-`pip` makes sure the two Python dependencies are installed and adds them
-if missing.
+Run `pip uninstall MPh` to remove the package from your system.
+
+Requires [JPype] for the bridge from Python to [Comsol's Java API]
+and [NumPy] for returning (fast) numerical arrays. Pip makes sure the
+two Python dependencies are installed and adds them if missing.
 
 Comsol, obviously, you need to license and install yourself. Versions
 from Comsol 5.1 onward are expected to work, though only Comsol 5.5 and
 newer have been rigorously tested. A separate Java run-time environment
 is *not* required as Comsol ships with one already built in.
 
-On Linux and macOS, Comsol is expected to be found in its respective
-default location. On Windows, any custom install location is supported,
-as the installer stores that information in the central registry.
+Comsol is expected to be installed in the default location suggested by
+its installer. Though on Windows, custom locations are also supported,
+as the installer stores that information in the central registry, which
+MPh looks up.
 
-Though if, on Linux, you do have Comsol installed in a custom location,
-[create a symbolic link][symlink] in `~/.local`, have it point to that
-Comsol folder, and give it a name that starts with `comsol`.
+Additionally, whichever Comsol installation starts when you run `comsol`
+in the console, will be found as well, even if in a custom location.
 
-[pypi]:    https://pypi.python.org/pypi/mph
-[jpype]:   https://jpype.readthedocs.io
-[japi]:    https://comsol.com/documentation/COMSOL_ProgrammingReferenceManual.pdf
-[numpy]:   https://numpy.org
-[symlink]: https://www.howtogeek.com/287014
+If you want to be able to select an alternative Comsol installation via
+MPh's API, like by passing the `version` option to {func}`mph.start`,
+and that Comsol version happens to be installed in a custom location,
+you can [create a symbolic link] in `~/.local` on Linux and in
+`~/Application` on macOS. Have it point to the corresponding Comsol
+folder and give the link a name that starts with `comsol`.
+
+
+[available on PyPI]:      https://pypi.python.org/pypi/mph
+[JPype]:                  https://jpype.readthedocs.io
+[Comsol's Java API]:      https://comsol.com/documentation/COMSOL_ProgrammingReferenceManual.pdf
+[NumPy]:                  https://numpy.org
+[create a symbolic link]: https://www.howtogeek.com/287014

--- a/mph/client.py
+++ b/mph/client.py
@@ -12,7 +12,6 @@ from .config import option             # configuration
 ########################################
 import jpype                           # Java bridge
 import jpype.imports                   # Java object imports
-import platform                        # platform information
 import os                              # operating system
 from pathlib import Path               # file-system paths
 from logging import getLogger          # event logging
@@ -158,15 +157,16 @@ class Client:
         # Without this, pyTest will crash when starting the Java VM.
         # See "Errors reported by Python fault handler" in JPype docs.
         # The problem may be the SIGSEGV signal, see JPype issue #886.
-        if platform.system() == 'Windows' and faulthandler.is_enabled():
+        if discovery.system == 'Windows' and faulthandler.is_enabled():
             log.debug('Turning off Python fault handlers.')
             faulthandler.disable()
 
-        # On Windows, prepend the Java folder to the library search path.
+        # On Windows, prepend the JRE bin folder to the library search path.
         # See issue #49.
-        if platform.system() == 'Windows':
+        if discovery.system == 'Windows':
             path = os.environ['PATH']
-            os.environ['PATH'] = str(backend['java']) + os.pathsep + path
+            jre  = backend['jvm'].parent.parent
+            os.environ['PATH'] = str(jre) + os.pathsep + path
 
         # Start the Java virtual machine.
         log.debug(f'JPype version is {jpype.__version__}.')

--- a/mph/config.py
+++ b/mph/config.py
@@ -12,7 +12,8 @@ from logging import getLogger          # event logging
 ########################################
 # Globals                              #
 ########################################
-log = getLogger(__package__)           # event log
+system = platform.system()             # operating system
+log    = getLogger(__package__)        # event log
 
 options = {
     'session':  'platform-dependent',
@@ -59,7 +60,6 @@ def location():
     in the home directory on Linux, and in `Application Support` on
     macOS.
     """
-    system = platform.system()
     if system == 'Windows':
         return Path(os.environ['APPDATA'])/'MPh'
     elif system == 'Linux':

--- a/mph/discovery.py
+++ b/mph/discovery.py
@@ -10,23 +10,32 @@ information about install locations. On Linux and macOS, Comsol is
 expected to be installed at its respective default location. Though on
 Linux, the folder `.local` in the user's home directory is also
 searched to allow symbolic linking to a custom location.
+
+In a last step, we also run the shell command `where comsol` (on Windows)
+or `which comsol` (on Linux and macOS) to find a Comsol installation
+that isn't in a default location, but for which the the Comsol
+executable was added to the executable search path. Note, however, that
+duplicate installations will be ignored. That is, a Comsol installation
+found in a later step that reports the same version as one found in an
+earlier step will be ignored, regardless of install location.
 """
 
 ########################################
 # Dependencies                         #
 ########################################
 import platform                        # platform information
+import subprocess                      # external processes
 import re                              # regular expressions
-from subprocess import run, PIPE       # external processes
-from functools import lru_cache        # function cache
 from pathlib import Path               # file paths
+from functools import lru_cache        # function cache
 from sys import version_info           # Python version
 from logging import getLogger          # event logging
 
 ########################################
 # Globals                              #
 ########################################
-log = getLogger(__package__)           # event log
+system = platform.system()             # operating system
+log    = getLogger(__package__)        # event log
 
 
 ########################################
@@ -74,14 +83,14 @@ def parse(version):
 
 
 ########################################
-# Discovery mechanism                  #
+# Back-end discovery                   #
 ########################################
 
-def search_Windows():
-    """Searches for Comsol installations on a Windows system."""
+def search_registry():
+    """Returns Comsol executables found in the Windows Registry."""
 
-    # Collect all information in a list.
-    backends = []
+    log.debug('Searching Windows Registry for Comsol executables.')
+    executables = []
 
     # Import Windows-specific library for registry access.
     import winreg
@@ -91,9 +100,8 @@ def search_Windows():
     try:
         main_node = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, main_path)
     except FileNotFoundError:
-        error = 'Did not find Comsol registry entry.'
-        log.error(error)
-        raise LookupError(error) from None
+        log.error('Did not find Comsol registry entry.')
+        return []
 
     # Parse child nodes to get list of Comsol installations.
     index = 0
@@ -130,272 +138,224 @@ def search_Windows():
         root = Path(value[0])
         log.debug(f'Checking installation folder "{root}".')
 
-        # Check that Comsol server executable exists.
-        server = root/'bin'/'win64'/'comsolmphserver.exe'
-        if not server.exists():
-            log.debug('Did not find Comsol server executable.')
+        # Only add to list if Comsol executable exists in sub-folder.
+        comsol = root/'bin'/'win64'/'comsol.exe'
+        if not comsol.exists():
+            log.debug('Did not find Comsol executable.')
             continue
+        executables.append(comsol)
 
-        # Get version information from Comsol server.
-        command = [server, '--version']
-        if version_info < (3, 8):
-            command[0] = str(command[0])
-        process = run(command, stdout=PIPE, creationflags=0x08000000)
-        if process.returncode != 0:
-            log.debug('Querying version information failed.')
-            continue
-        version = process.stdout.decode('ascii', errors='ignore').strip()
-        log.debug(f'Reported version info is "{version}".')
-
-        # Parse version information.
-        try:
-            (name, major, minor, patch, build) = parse(version)
-        except ValueError as error:
-            log.debug(error)
-            continue
-        log.debug(f'Assigned name "{name}" to this installation.')
-
-        # Ignore installation if version name is a duplicate.
-        if name in (backend['name'] for backend in backends):
-            log.warning(f'Ignoring duplicate of Comsol version {name}.')
-            continue
-
-        # Verify existence of required files and folders.
-        jre = root/'java'/'win64'/'jre'
-        if not jre.exists():
-            log.debug('Did not find Java run-time environment.')
-            continue
-        java = jre/'bin'
-        if not java.exists():
-            log.debug('Did not find Java run-time binaries.')
-            continue
-        jvm = java/'server'/'jvm.dll'
-        if not jvm.exists():
-            log.debug('Did not find Java virtual machine.')
-            continue
-        api = root/'plugins'
-        if not api.exists():
-            log.debug('Did not find Comsol Java API plug-ins.')
-            continue
-        lib = root/'lib'/'win64'
-        if not lib.exists():
-            log.debug('Did not find Comsol shared libraries.')
-            continue
-
-        # Collect all information in a dictionary and add it to the list.
-        backends.append({
-            'name':   name,
-            'major':  major,
-            'minor':  minor,
-            'patch':  patch,
-            'build':  build,
-            'root':   root,
-            'java':   java,
-            'jvm':    jvm,
-            'server': [server],
-        })
-
-    # Return list with information about all installed Comsol back-ends.
-    return backends
+    # Return list with file-system paths of Comsol executables.
+    return executables
 
 
-def search_Linux():
-    """Searches for Comsol installations on a Linux system."""
+def search_disk():
+    """Returns Comsol executables found on the file system."""
 
-    # Collect all information in a list.
-    backends = []
+    log.debug('Searching file system for Comsol executables.')
+    executables = []
 
-    # Loop over Comsol folders in `/usr/local` and `~/.local`.
-    pattern   = re.compile('(?i)Comsol')
-    locations = [Path('/usr/local'), Path.home()/'.local']
-    folders   = [item for location in locations
-                      for item in location.iterdir()
-                      if item.is_dir() and pattern.match(item.name)]
+    # Check folders in following locations, depending on operating system.
+    if system == 'Linux':
+        locations = [
+            Path('/usr/local'),
+            Path.home() / '.local',
+        ]
+    elif system == 'Darwin':
+        locations = [
+            Path('/Applications'),
+            Path.home() / 'Applications',
+            Path.home() / 'Library',
+            Path.home() / '.local',
+        ]
+
+    # Look for Comsol executables at those locations.
+    folders = [item for location in locations
+                    for item in location.iterdir()
+                    if item.is_dir() and re.match('(?i)comsol', item.name)]
     for folder in folders:
+        log.debug(f'Checking candidate folder "{folder}".')
 
-        # Root folder is the sub-directory "multiphysics".
+        # Root folder is usually the sub-directory "multiphysics".
+        # But we also accept that this (pointless) folder is missing.
         root = folder/'multiphysics'
         if not root.is_dir():
-            log.debug(f'No folder "multiphysics" in "{folder.name}".')
-            continue
-        log.debug(f'Checking installation folder "{root}".')
+            log.debug('No sub-folder named "multiphysics".')
+            root = folder
 
-        # Check that Comsol executable exists.
-        comsol = root/'bin'/'glnxa64'/'comsol'
+        # Only add to list if Comsol executable exists in correct sub-folder.
+        if system == 'Linux':
+            comsol = root/'bin'/'glnxa64'/'comsol'
+        elif system == 'Darwin':
+            comsol = root/'bin'/'maci64'/'comsol'
         if not comsol.exists():
             log.debug('Did not find Comsol executable.')
             continue
+        log.debug(f'Found Comsol executable "{comsol}".')
+        executables.append(comsol)
 
-        # Get version information from Comsol server.
-        process = run([comsol, 'mphserver', '--version'], stdout=PIPE)
-        if process.returncode != 0:
-            log.debug('Querying version information failed.')
-            continue
-        version = process.stdout.decode('ascii', errors='ignore').strip()
-        log.debug(f'Reported version info is "{version}".')
-
-        # Parse version information.
-        try:
-            (name, major, minor, patch, build) = parse(version)
-        except ValueError as error:
-            log.debug(error)
-            continue
-        log.debug(f'Assigned name "{name}" to this installation.')
-
-        # Ignore installation if version name is a duplicate.
-        if name in (backend['name'] for backend in backends):
-            log.warning(f'Ignoring duplicate of Comsol version {name}.')
-            continue
-
-        # Verify existence of required files and folders.
-        jre = root/'java'/'glnxa64'/'jre'
-        if not jre.exists():
-            log.debug('Did not find Java run-time environment.')
-            continue
-        java = jre/'bin'
-        if not java.exists():
-            log.debug('Did not find Java run-time binaries.')
-            continue
-        jvm = jre/'lib'/'server'/'libjvm.so'
-        if not jvm.exists():
-            # Old location, up until Comsol 5.6.
-            jvm = jre/'lib'/'amd64'/'server'/'libjvm.so'
-            if not jvm.exists():
-                log.debug('Did not find Java virtual machine.')
-                continue
-        api = root/'plugins'
-        if not api.exists():
-            log.debug('Did not find Comsol Java API plug-ins.')
-            continue
-        lib = root/'lib'/'glnxa64'
-        if not lib.exists():
-            log.debug('Did not find Comsol shared libraries.')
-            continue
-        gra = root/'ext'/'graphicsmagick'/'glnxa64'
-        if not gra.exists():
-            log.debug('Did not find graphics libraries.')
-            continue
-
-        # Collect all information in a dictionary and add it to the list.
-        backends.append({
-            'name':   name,
-            'major':  major,
-            'minor':  minor,
-            'patch':  patch,
-            'build':  build,
-            'root':   root,
-            'jvm':    jvm,
-            'java':   java,
-            'server': [comsol, 'mphserver'],
-        })
-
-    # Return list with information about all installed Comsol back-ends.
-    return backends
+    # Return list with file-system paths of Comsol executables.
+    return executables
 
 
-def search_macOS():
-    """Searches for Comsol installations on a macOS system."""
+def lookup_comsol():
+    """Returns Comsol executable if found on the system's search path."""
 
-    # Collect all information in a list.
-    backends = []
+    log.debug('Looking for Comsol executable on system search path.')
 
-    # Loop over Comsol folders in /Applications.
-    pattern = re.compile('(?i)Comsol')
-    folders = [item for item in Path('/Applications').iterdir()
-               if item.is_dir() and pattern.match(item.name)]
-    for folder in folders:
+    # Check if Comsol executable is on search path.
+    command = 'where comsol' if system == 'Windows' else 'which comsol'
+    try:
+        log.debug(f'Running shell command "{command}".')
+        process = subprocess.run(
+            command, shell=True, check=True, timeout=3,
+            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+            universal_newlines=True, encoding='UTF-8',
+        )
+        # Change `universal_newlines` to `text` when dropping Python 3.6.
+    except subprocess.CalledProcessError:
+        log.debug('Command exited with an error.')
+        return
+    except subprocess.TimeoutExpired:
+        log.debug('Command execution timed out.')
+        return
+    response = process.stdout.strip()
+    log.debug(f'Command response was "{response}".')
 
-        # Root folder is the sub-directory "Multiphysics".
-        root = folder/'Multiphysics'
-        if not root.is_dir():
-            log.debug(f'No folder "Multiphysics" in "{folder.name}".')
-            continue
-        log.debug(f'Checking installation folder "{root}".')
+    # Assert that Comsol executable actually exists where reported.
+    try:
+        comsol = Path(response).resolve(strict=True)
+    except FileNotFoundError:
+        log.debug('No Comsol executable found at that path.')
+        return
+    log.debug(f'Found Comsol executable "{comsol}".')
 
-        # Check that Comsol executable exists.
-        comsol = root/'bin'/'maci64'/'comsol'
-        if not comsol.exists():
-            log.debug('Did not find Comsol executable.')
-            continue
-
-        # Get version information from Comsol server.
-        process = run([comsol, 'mphserver', '--version'], stdout=PIPE)
-        if process.returncode != 0:
-            log.debug('Querying version information failed.')
-            continue
-        version = process.stdout.decode('ascii', errors='ignore').strip()
-        log.debug(f'Reported version info is "{version}".')
-
-        # Parse version information.
-        try:
-            (name, major, minor, patch, build) = parse(version)
-        except ValueError as error:
-            log.debug(error)
-            continue
-        log.debug(f'Assigned name "{name}" to this installation.')
-
-        # Ignore installation if version name is a duplicate.
-        if name in (backend['name'] for backend in backends):
-            log.warning(f'Ignoring duplicate of Comsol version {name}.')
-            continue
-
-        # Verify existence of required files and folders.
-        jre = root/'java'/'maci64'/'jre'
-        if not jre.exists():
-            log.debug('Did not find Java run-time environment.')
-            continue
-        java = jre/'Contents'/'Home'/'bin'
-        if not java.exists():
-            log.debug('Did not find Java run-time binaries.')
-            continue
-        jvm = jre/'Contents'/'Home'/'lib'/'server'/'libjvm.dylib'
-        if not jvm.exists():
-            log.debug('Did not find Java virtual machine.')
-            continue
-        api = root/'plugins'
-        if not api.exists():
-            log.debug('Did not find Comsol Java API plug-ins.')
-            continue
-        lib = root/'lib'/'maci64'
-        if not lib.exists():
-            log.debug('Did not find Comsol shared libraries.')
-            continue
-        gra = root/'ext'/'graphicsmagick'/'maci64'
-        if not gra.exists():
-            log.debug('Did not find graphics libraries.')
-            continue
-
-        # Collect all information in a dictionary and add it to the list.
-        backends.append({
-            'name':   name,
-            'major':  major,
-            'minor':  minor,
-            'patch':  patch,
-            'build':  build,
-            'root':   root,
-            'jvm':    jvm,
-            'java':   java,
-            'server': [comsol, 'mphserver'],
-        })
-
-    # Return list with information about all installed Comsol back-ends.
-    return backends
+    # Return executable that we found.
+    return comsol
 
 
 @lru_cache(maxsize=1)
-def search_system():
-    """Searches the system for Comsol installations."""
-    system = platform.system()
+def find_backends():
+    """Returns the list of available Comsol back-ends."""
+
+    log.debug('Searching system for available Comsol back-ends.')
+    backends = []
+
+    # Search system for Comsol executables.
     if system == 'Windows':
-        return search_Windows()
-    elif system == 'Linux':
-        return search_Linux()
-    elif system == 'Darwin':
-        return search_macOS()
+        executables = search_registry()
+    elif system in ('Linux', 'Darwin'):
+        executables = search_disk()
     else:
         error = f'Unsupported operating system "{system}".'
         log.error(error)
         raise NotImplementedError(error)
+
+    # Look up `comsol` command as if run in terminal.
+    comsol = lookup_comsol()
+    if comsol:
+        if comsol not in executables:
+            executables.append(comsol)
+        else:
+            log.debug('Ignoring executable as it was previously found.')
+
+    # Only accept executable when Java API was found as well.
+    for comsol in executables:
+        log.debug(f'Checking executable: "{comsol}".')
+
+        # Get folder of executable and root folder of installation.
+        folder = comsol.parent
+        root   = folder.parent.parent
+
+        # Check that Java bridge configuration exists in same folder.
+        ini = folder/'comsol.ini'
+        if not ini.exists():
+            log.debug(f'Did not find Java bridge configuration "{ini.name}".')
+            continue
+
+        # Check that folder with Comsol Java API exists.
+        api = root/'plugins'
+        if not api.exists():
+            log.debug('Did not find Comsol Java API plug-ins.')
+
+        # On Windows, check that server executable exists in same folder.
+        if system == 'Windows':
+            server = folder/'comsolmphserver.exe'
+            if not server.exists():
+                log.debug('Did not find "{server.name}" in "{folder}".')
+            server = [server]
+        else:
+            server = [comsol, 'mphserver']
+
+        # Get version information from Comsol server.
+        command = server + ['--version']
+        if version_info < (3, 8):
+            command[0] = str(command[0])
+        try:
+            arguments = dict(check=True, timeout=5, stdout=subprocess.PIPE)
+            if system == 'Windows':
+                arguments['creationflags'] = 0x08000000
+            process = subprocess.run(command, **arguments)
+        except subprocess.CalledProcessError:
+            log.debug('Querying version information failed.')
+            continue
+        except subprocess.TimeoutExpired:
+            log.debug('Querying version information timed out.')
+            continue
+        version = process.stdout.decode('ascii', errors='ignore').strip()
+        log.debug(f'Reported version information is "{version}".')
+
+        # Parse version information.
+        try:
+            (name, major, minor, patch, build) = parse(version)
+        except ValueError as error:
+            log.debug(error)
+            continue
+        log.debug(f'Assigned name "{name}" to this installation.')
+
+        # Ignore installation if version name is a duplicate.
+        if name in (backend['name'] for backend in backends):
+            log.debug(f'Ignoring duplicate of Comsol version {name}.')
+            continue
+
+        # Parse Java bridge configuration.
+        with ini.open(encoding='UTF-8') as stream:
+            jvm_on_next_line = False
+            for line in stream:
+                line = line.strip()
+                if not line or line.startswith('#'):
+                    continue
+                if jvm_on_next_line:
+                    jvm_path = line
+                    break
+                if line == '-vm':
+                    jvm_on_next_line = True
+            else:
+                log.debug(f'Did not find Java VM path in "{ini.name}".')
+                continue
+        log.debug(f'Relative path to Java VM: "{jvm_path}".')
+
+        # Resolve Java VM path.
+        try:
+            jvm = (folder/jvm_path).resolve(strict=True)
+        except FileNotFoundError:
+            log.debug('Did not find Java virtual machine.')
+            continue
+
+        # Collect all information in a dictionary and add it to the list.
+        backends.append({
+            'name':   name,
+            'major':  major,
+            'minor':  minor,
+            'patch':  patch,
+            'build':  build,
+            'root':   root,
+            'jvm':    jvm,
+            'server': server,
+        })
+
+    # Return list with information about all installed Comsol back-ends.
+    return backends
 
 
 ########################################
@@ -410,7 +370,7 @@ def backend(version=None):
     are installed, for example `version='5.3a'`. Otherwise the latest
     version is used.
     """
-    backends = search_system()
+    backends = find_backends()
     if not backends:
         error = 'Could not locate any Comsol installation.'
         log.error(error)

--- a/mph/session.py
+++ b/mph/session.py
@@ -24,6 +24,7 @@ from logging import getLogger          # event logging
 client = None                          # client instance
 server = None                          # server instance
 thread = None                          # current thread
+system = platform.system()             # operating system
 log    = getLogger(__package__)        # event log
 
 
@@ -90,7 +91,7 @@ def start(cores=None, version=None, port=0):
 
     session = option('session')
     if session == 'platform-dependent':
-        if platform.system() == 'Windows':
+        if system == 'Windows':
             session = 'stand-alone'
         else:
             session = 'client-server'
@@ -166,7 +167,7 @@ def cleanup():
         # pyTest exits. But disabling the fault handler doesn't help,
         # so let's not touch it. It does seem to have some effect on
         # Windows, but even there the benefit is fairly unclear.
-        if platform.system() == 'Windows' and faulthandler.is_enabled():
+        if system == 'Windows' and faulthandler.is_enabled():
             log.debug('Turning off Python fault handlers.')
             faulthandler.disable()
         # Exit the hard way as Comsol leaves us no choice. See issue #38.

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -25,7 +25,6 @@ def test_backend():
     backend = mph.discovery.backend()
     assert backend['name']
     assert backend['root']
-    assert backend['java']
     assert backend['jvm']
     assert backend['server']
 


### PR DESCRIPTION
The discovery mechanism was refactored. We are now first looking for
Comsol executables, i.e. `comsol.exe` on Windows or `comsol` on Linux
and macOS. We can then add to the list of candidates the Comsol
executable that the shell would find, if any, i.e. what would be called
when running `comsol` in the terminal.

This makes discovery more flexible, since that last installation does
not necessarily have to be in a default location. So finding it requires
no extra configuration other than "adding Comsol to PATH", which the
Comsol installer offers as an option (named not exactly like that, but
something to that effect).

So when there is but this one Comsol installation, MPh should work out
of the box, without the need to create symbolic links if that installation
is in a non-default location.

We retain the possibility of selecting a specific Comsol back-end, for
the purpose of running tests/benchmark across versions. If the
back-end on the executable search path (a.k.a. the `PATH`) is the same
as one of those already found by searching the system (file system on
Linux and macOS, the Registry on Windows), then we'll ignore it.

To achieve this functionality, we are now starting our search for other
Comsol components such as the Java VM from the location of the
Comsol executable, i.e. `comsol.exe` or the `comsol` shell script.
We then look for `comsol.ini` in the same folder and parse it in order
to get the relative path to the Java VM.