### PR TITLE
Add support for material property groups

### DIFF
--- a/mph/node.py
+++ b/mph/node.py
@@ -215,7 +215,12 @@ class Node:
         java = parent.java
         if not java:
             return None
-        container = java if parent.is_group() else java.feature()
+        if parent.is_group():
+            container = java
+        elif hasattr(java, 'propertyGroup'):
+            container = java.propertyGroup()
+        else:
+            container = java.feature()
         for tag in container.tags():
             member = container.get(tag)
             if name == escape(member.label()):
@@ -260,6 +265,9 @@ class Node:
             return [self.__class__(self.model, group) for group in self.groups]
         elif self.is_group():
             return [self/escape(java.get(tag).label()) for tag in java.tags()]
+        elif hasattr(java, 'propertyGroup'):
+            return [self/escape(java.propertyGroup(tag).label())
+                    for tag in java.propertyGroup().tags()]
         elif hasattr(java, 'feature'):
             return [self/escape(java.feature(tag).label())
                     for tag in java.feature().tags()]
@@ -579,6 +587,8 @@ class Node:
                 container = java.feature()
             elif hasattr(java, 'uniquetag') and hasattr(java, 'create'):
                 container = java
+        elif hasattr(java, 'propertyGroup'):
+            container = java.propertyGroup()
         elif hasattr(java, 'feature'):
             container = java.feature()
         if not hasattr(container, 'uniquetag'):
@@ -635,7 +645,13 @@ class Node:
             log.error(error)
             raise LookupError(error)
         parent = self.parent()
-        container = parent.java if parent.is_group() else parent.java.feature()
+        java = parent.java
+        if parent.is_group():
+            container = java
+        elif hasattr(java, 'propertyGroup'):
+            container = java.propertyGroup()
+        else:
+            container = java.feature()
         container.remove(self.java.tag())
 
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -62,5 +62,6 @@ def setup_logging():
         return
     logging.setLogRecordFactory(timed_records)
     logging.basicConfig(
-        level   = logging.DEBUG,
-        format  = '[%(timestamp)s] %(message)s')
+        level  = logging.DEBUG,
+        format = '[%(timestamp)s] %(message)s',
+    )


### PR DESCRIPTION
As pointed out in issue #78, the material property groups, such as
"Basic" for the material "medium 1" in the demo model, did not show up
in the model tree as displayed by `mph.tree()`. We also could not
access those properties via the `Node.property()` method.

We fix that by also considering "property groups" (in addition to
"feature groups") as Java containers for children of a given node
when traversing the model tree.