### PR TITLE
Add `problems()` method to `Model` class

### DIFF
--- a/mph/model.py
+++ b/mph/model.py
@@ -246,6 +246,18 @@ class Model:
         """Returns the names of modules/products required to be licensed."""
         return [modules.get(key, key) for key in self.java.getUsedProducts()]
 
+    def problems(self):
+        """
+        Returns problems reported by nodes in the model.
+
+        See {meth}`Node.problems` on how problems (error/warning
+        messages and their origin) are returned. First and foremost,
+        this method lets users check if any problems are reported
+        throughout the model by testing `if model.problems():` in
+        application code, to then act accordingly.
+        """
+        return (self/None).problems()
+
     ####################################
     # Solving                          #
     ####################################

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -709,6 +709,21 @@ def test_save():
             model.save('model.mph', format='invalid')
 
 
+def test_problems():
+    assert not model.problems()
+    anode = model/'physics'/'electrostatic'/'anode'
+    anode.property('V0', '+Ua/2')
+    study = model/'studies'/'static'
+    try:
+        study.run()
+    except Exception:
+        pass
+    assert model.problems()
+    anode.property('V0', '+U/2')
+    study.run()
+    assert not model.problems()
+
+
 def test_features():
     with warnings_disabled():
         assert 'Laplace equation' in model.features('electrostatic')
@@ -790,6 +805,7 @@ if __name__ == '__main__':
         test_datasets()
         test_plots()
         test_exports()
+        test_modules()
 
         test_build()
         test_mesh()
@@ -814,6 +830,8 @@ if __name__ == '__main__':
         test_clear()
         test_reset()
         test_save()
+
+        test_problems()
 
         test_features()
         test_toggle()


### PR DESCRIPTION
The `Model` class gets a new API method `problems()`. All it does is
call the `problems()` method of its root node. This gives users an
easy way to check if there are any problems reported throughout the
model, by testing `if model.problems():` in application code, to then
act accordingly.