### PR TITLE
Fix missing time steps when evaluating parameter sweeps

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -320,6 +320,13 @@ def test_evaluate():
     D = model.evaluate(expression, unit, dataset, outer=2)
     assert (D[0]  == Df).all()
     assert (D[-1] == Dl).all()
+    # Test varying time steps in parameter sweep. See issue #112.
+    study = model/'studies'/'sweep'
+    (study/'time-dependent').property('tlist', 'range(0, 0.01/d[1/mm], 1)')
+    model.solve(study)
+    assert len(model.evaluate('t', 's', 'parametric sweep', outer=1)) == 101
+    assert len(model.evaluate('t', 's', 'parametric sweep', outer=2)) == 201
+    assert len(model.evaluate('t', 's', 'parametric sweep', outer=3)) == 301
     # Test evaluation of complex-valued global expressions.
     U = model.evaluate('U')
     z = model.evaluate('U + j*U')


### PR DESCRIPTION
In parametric sweeps where the number of time steps depends on the parameter, the number of time steps returned always corresponded to the first outer solution, i.e. the first parameter value. In evaluations of other outer solutions, the additional time steps were then missing. See issue #112.

We now use an `EvalGlobal` feature instead of a `Global` evaluation feature, and call `computeResult` instead of `getData`. This fixes the issue, though it is not clear (to me) from the Comsol API documentation why the two feature types and method calls behave differently.

https://doc.comsol.com/6.1/doc/com.comsol.help.comsol/api/com/comsol/model/NumericalFeature.html