### PR TITLE
Change classpath to `apiplugins` fixing #114

### DIFF
--- a/mph/client.py
+++ b/mph/client.py
@@ -176,7 +176,10 @@ class Client:
         if option('classkit'):
             args += ['-Dcs.ckl']
         log.debug(f'JVM arguments: {args}')
-        jpype.startJVM(*args, classpath=str(root/'apiplugins'/'*'))
+        if standalone:
+            jpype.startJVM(*args, classpath=str(root/'plugins'/'*'))
+        else:
+            jpype.startJVM(*args, classpath=str(root/'apiplugins'/'*'))
         log.info('Java virtual machine has started.')
 
         # Import Comsol client object, a static class, i.e. singleton.

--- a/mph/client.py
+++ b/mph/client.py
@@ -176,7 +176,7 @@ class Client:
         if option('classkit'):
             args += ['-Dcs.ckl']
         log.debug(f'JVM arguments: {args}')
-        jpype.startJVM(*args, classpath=str(root/'plugins'/'*'))
+        jpype.startJVM(*args, classpath=str(root/'apiplugins'/'*'))
         log.info('Java virtual machine has started.')
 
         # Import Comsol client object, a static class, i.e. singleton.

--- a/mph/client.py
+++ b/mph/client.py
@@ -168,6 +168,9 @@ class Client:
             jre  = backend['jvm'].parent.parent
             os.environ['PATH'] = str(jre) + os.pathsep + path
 
+        # This is a stand-alone client if no port given.
+        standalone = host and not port
+
         # Start the Java virtual machine.
         log.debug(f'JPype version is {jpype.__version__}.')
         log.info('Starting Java virtual machine.')
@@ -185,9 +188,6 @@ class Client:
         # Import Comsol client object, a static class, i.e. singleton.
         # See `ModelUtil()` constructor in [1].
         from com.comsol.model.util import ModelUtil as java
-
-        # This is a stand-alone client if no port given.
-        standalone = host and not port
 
         # Possibly initialize the stand-alone client.
         if standalone:


### PR DESCRIPTION
This PR implements a change required to fix #114 (at least on my system). The classpath is changed from `plugins` to `apiplugins`.

All the tests in `tools/test.py` complete successfully after this. Needs to be verified that it works on other OS as well.