### PR TITLE
Option to load model as a copy (read only mode)

### DIFF
--- a/mph/client.py
+++ b/mph/client.py
@@ -315,7 +315,11 @@ class Client:
     ####################################
 
     def load(self, file, copy=False):
-        """Loads a model from the given `file` and returns it."""
+        """
+        Loads a model from the given `file` and returns it.
+        
+        The model can be loaded as readonly by setting the copy flag.
+        """
         file = Path(file).resolve()
         if self.caching() and file in self.files():
             log.info(f'Retrieving "{file.name}" from cache.')
@@ -324,6 +328,7 @@ class Client:
         if copy:
             log.info(f'Loading model "{file.name}" in read only mode.')
             model = Model(self.java.loadCopy(tag, str(file)))
+            model.readonly = True
         else:
             log.info(f'Loading model "{file.name}".')
             model = Model(self.java.load(tag, str(file)))

--- a/mph/client.py
+++ b/mph/client.py
@@ -314,15 +314,19 @@ class Client:
     # Interaction                      #
     ####################################
 
-    def load(self, file):
+    def load(self, file, copy=False):
         """Loads a model from the given `file` and returns it."""
         file = Path(file).resolve()
         if self.caching() and file in self.files():
             log.info(f'Retrieving "{file.name}" from cache.')
             return self.models()[self.files().index(file)]
         tag = self.java.uniquetag('model')
-        log.info(f'Loading model "{file.name}".')
-        model = Model(self.java.load(tag, str(file)))
+        if copy:
+            log.info(f'Loading model "{file.name}" in read only mode.')
+            model = Model(self.java.loadCopy(tag, str(file)))
+        else:
+            log.info(f'Loading model "{file.name}".')
+            model = Model(self.java.load(tag, str(file)))
         log.info('Finished loading model.')
         return model
 


### PR DESCRIPTION
I would like to have this option to be able to load the model in safely as a copy (read only mode). I suggested this earlier (
https://github.com/MPh-py/MPh/pull/82), but I got caught up in other work so we didn't get it in at that time - sorry!


Now suggesting it again but as a very minimal change :)
