### PR TITLE
Support Apple Silicon system architecture

### DIFF
--- a/mph/discovery.py
+++ b/mph/discovery.py
@@ -39,7 +39,7 @@ system = platform.system()             # operating system
 architectures = {                      # valid system architecture names
     'Windows': ['win64'],
     'Linux':   ['glnxa64'],
-    'Darwin':  ['maci64'],
+    'Darwin':  ['maci64','macarm64'],
 }
 
 


### PR DESCRIPTION
Currently, only "maci64" (presumably for Intel-based macOS systems) is listed under the Darwin architecture names in ``discovery.py``. I have added the corresponding name to include Apple Silicon–based systems.