### PR TITLE
Add support for ARM-based Apple Silicon architecture on macOS

### DIFF
--- a/mph/discovery.py
+++ b/mph/discovery.py
@@ -219,7 +219,7 @@ def search_disk(architecture: str) -> list[Path]:
             root = folder
 
         # Make sure Comsol executable exists in platform-specific sub-folder.
-        comsol = root/'bin'/architecture/'comsol.exe'
+        comsol = root/'bin'/architecture/'comsol'
         if not comsol.is_file():
             log.debug(f'Did not find Comsol executable in "{comsol.parent}".')
             continue


### PR DESCRIPTION
This required a bit of refactoring in the discovery code. We now detect the platform architecture right upfront and use it to inform our expectation of the name of Comsol's binary folder, such as `win64` or `macarm64`. We don't expect it to behave any different on platforms that were previously already supported.

Supersedes (but includes) #227. Solves #80.