### PR TITLE
Input argument for explicit path comsol installation

### DIFF
--- a/mph/client.py
+++ b/mph/client.py
@@ -105,6 +105,9 @@ class Client:
     A specific Comsol `version` can be selected if several are installed, for
     example `version='6.0'`. Otherwise the latest version is used.
 
+    A `path` to a Comsol executable can be specified, e.g. `path='/.../comsol'`
+    in Linux and `path='C:\...\comsol.exe'` in Windows.
+
     Initializes a stand-alone Comsol session if no `port` number is specified.
     Otherwise tries to connect to the Comsol server listening at the given port
     for client connections.
@@ -151,6 +154,7 @@ class Client:
     def __init__(self,
         cores:   int = None,
         version: str = None,
+        path:    str = None,
         port:    int = None,
         host:    str = 'localhost',
     ):
@@ -162,7 +166,7 @@ class Client:
             raise NotImplementedError(error)
 
         # Discover Comsol back-end.
-        backend = discovery.backend(version)
+        backend = discovery.backend(version, path)
 
         # On Windows, turn off fault handlers if enabled.
         # Without this, pyTest will crash when starting the Java VM.

--- a/mph/discovery.py
+++ b/mph/discovery.py
@@ -273,8 +273,12 @@ def search_path() -> Path | None:
 
 
 @lru_cache(maxsize=1)
-def find_backends() -> list[Backend]:
-    """Returns the list of available Comsol back-ends."""
+def find_backends(path: str = None) -> list[Backend]:
+    """
+    Returns the list of available Comsol back-ends.
+    
+    A `path` to a Comsol executable can be given.
+    """
 
     log.debug('Searching system for available Comsol back-ends.')
     backends = []
@@ -287,27 +291,37 @@ def find_backends() -> list[Backend]:
     log.debug(f'NumPy version is {numpy_version}.')
     log.debug(f'JPype version is {jpype_version}.')
 
-    # Search system for Comsol executables.
-    if system == 'Windows':
-        executables = search_registry(arch)
-    elif system in ('Linux', 'Darwin'):
-        executables = search_disk(arch)
+    if path is not None:
+        # Resolve Comsol executable at the given path.
+        try:
+            comsol = Path(path).resolve(strict=True)
+        except FileNotFoundError:
+            log.debug('No Comsol executable found at the specified path.')
+            return
+        executables = [comsol]
     else:
-        error = f'Unsupported operating system "{system}".'
-        log.error(error)
-        raise NotImplementedError(error)
-
-    # Look up `comsol` command as if run in terminal.
-    comsol = search_path()
-    if comsol:
-        if comsol not in executables:
-            executables.insert(0, comsol)
-            # We put that Comsol executable first so that users have a way of
-            # prioritizing one Comsol installation over another. This makes
-            # sense for multiple installations of the same Comsol version, each
-            # with a single-user license for a different user.
+        # Search system for Comsol executables.
+        if system == 'Windows':
+            executables = search_registry(arch)
+        elif system in ('Linux', 'Darwin'):
+            executables = search_disk(arch)
         else:
-            log.debug('Ignoring executable as it was previously found.')
+            error = f'Unsupported operating system "{system}".'
+            log.error(error)
+            raise NotImplementedError(error)
+
+        # Look up `comsol` command as if run in terminal.
+        comsol = search_path()
+
+        if comsol:
+            if comsol not in executables:
+                executables.insert(0, comsol)
+                # We put that Comsol executable first so that users have a way of
+                # prioritizing one Comsol installation over another. This makes
+                # sense for multiple installations of the same Comsol version, each
+                # with a single-user license for a different user.
+            else:
+                log.debug('Ignoring executable as it was previously found.')
 
     # Only accept executable when Java API was found as well.
     for comsol in executables:
@@ -435,19 +449,28 @@ def find_backends() -> list[Backend]:
     return backends
 
 
-def backend(version: str = None) -> Backend:
+def backend(version: str = None, path: str = None) -> Backend:
     """
     Returns information about the Comsol back-end.
 
     A specific Comsol `version` can be selected by name if several are
     installed, for example `version='6.0'`. Otherwise the latest version is
     used.
+
+    A `path` to a Comsol executable can be specified, e.g. `path='/.../comsol'`
+    in Linux and `path='C:\...\comsol.exe'` in Windows. If both `version`
+    and `path` are given, the `version` argument is ignored.
     """
-    backends = find_backends()
+    backends = find_backends(path)
     if not backends:
         error = 'Could not find a supported Comsol installation.'
         log.error(error)
         raise RuntimeError(error)
+
+    if version is not None and path is not None:
+        log.debug('Ignoring specified version as path argument was given.')
+        version = None
+
     if version is None:
         numbers = [
             (

--- a/mph/server.py
+++ b/mph/server.py
@@ -46,6 +46,9 @@ class Server:
     installed on the machine, for example `version='6.0'`. Otherwise the latest
     version is used.
 
+    A `path` to a Comsol executable can be specified, e.g. `path='/.../comsol'`
+    in Linux and `path='C:\...\comsol.exe'` in Windows.
+
     The server can be instructed to use a specific network `port` for
     communication with clients by passing the number of a free port explicitly.
     If `port=None`, the default, the server will try to use port 2036 or, in
@@ -72,6 +75,7 @@ class Server:
     def __init__(self,
         cores:     int = None,
         version:   str = None,
+        path:      str = None,
         port:      int = None,
         multi:     bool | Literal['on', 'off'] | None = None,
         timeout:   int = 60,
@@ -82,7 +86,7 @@ class Server:
         extra_arguments = arguments if arguments else []
 
         # Start Comsol server as an external process.
-        backend = discovery.backend(version)
+        backend = discovery.backend(version, path)
         server  = backend['server']
         log.info('Starting external server process.')
         arguments = ['-login', 'auto', '-graphics', '-autosave', 'off']

--- a/mph/session.py
+++ b/mph/session.py
@@ -32,6 +32,7 @@ log    = getLogger(__package__)
 def start(
     cores:   int = None,
     version: str = None,
+    path:    str = None,
     port:    int = 0,
 ) -> Client:
     """
@@ -70,6 +71,9 @@ def start(
     A specific Comsol `version` can be selected if several are installed, for
     example `version='6.0'`. Otherwise the latest version is used.
 
+    A `path` to a Comsol executable can be specified, e.g. `path='/.../comsol'`
+    in Linux and `path='C:\...\comsol.exe'` in Windows.
+
     The server `port` can be specified if client–server mode is used. If
     omitted, the server chooses a random free port.
     """
@@ -100,10 +104,10 @@ def start(
 
     log.info('Starting local Comsol session.')
     if session == 'stand-alone':
-        client = Client(cores=cores, version=version)
+        client = Client(cores=cores, version=version, path=path)
     elif session == 'client-server':
-        server = Server(cores=cores, version=version, port=port)
-        client = Client(cores=cores, version=version, port=server.port)
+        server = Server(cores=cores, version=version, path=path, port=port)
+        client = Client(cores=cores, version=version, path=path, port=server.port)
     else:
         error = f'Invalid session type "{session}".'
         log.error(error)


### PR DESCRIPTION
Hi there,
I ran into an issue using the library on a Linux cluster where the COMSOL installation was in a non-standard location. As a result, it couldn't be detected by `discovery.search_disk()` and `discovery.search_path()`. I've implemented an optional argument to allow users to provide an explicit installation path.

Please note that this is my first PR here, and I have only been able to test these changes on Linux. Thanks for maintaining such a great project! 🙌