### PR TITLE
Fix `test_model.py::test_modules` failing with Comsol 6.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,7 @@ include = [
         'RUF002',             # docstring with en-dash
         'RUF013',             # no implicit optional types by assigning `None`
         'RUF036',             # `None` not at end of type annotation
+        'RUF069',             # unreliable floating point equality comparison
         'UP024',              # Replace `IOError` with `OSError`.
     ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ test = [
     'codecov      >= 2',
 ]
 docs = [
-    'Sphinx      >= 8',
+    'Sphinx      >= 8, < 9',
     'MyST-parser >= 1',
     'Furo        >= 2024',
 ]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -89,8 +89,11 @@ def test_files():
 
 def test_modules():
     Comsol62_or_older = (version.parse(client.version) < version.parse('6.3'))
+    Comsol64_or_later = (version.parse(client.version) >= version.parse('6.4'))
     for key in mph.client.modules:
         if key == 'ELECTRICDISCHARGE' and Comsol62_or_older:
+            continue
+        if key == 'OPTIMIZATION' and Comsol64_or_later:
             continue
         assert client.java.hasProduct(key) in (True, False)
     for value in mph.client.modules.values():


### PR DESCRIPTION
The test `test_modules()` in `test_model.py` was failing with Comsol 6.4, probably because that Comsol version no longer ships with the "Optimization" module that we were querying. I just excluded that from the test.