### PR TITLE
Link to Comsol API docs from doc-strings of `.java` attributes

### DIFF
--- a/mph/client.py
+++ b/mph/client.py
@@ -142,7 +142,11 @@ class Client:
     """Host name or IP address of the server the client is connected to."""
 
     java: JClass
-    """Java model object that this class instance is wrapped around."""
+    """
+    Java [`ModelUtil`] object that this singleton class wraps.
+
+    [`ModelUtil`]: https://doc.comsol.com/6.4/doc/com.comsol.help.comsol/api/com/comsol/model/util/ModelUtil.html
+    """
 
     ############
     # Internal #

--- a/mph/model.py
+++ b/mph/model.py
@@ -124,7 +124,11 @@ class Model:
     """
 
     java: JClass
-    """Java object that this instance is wrapped around."""
+    """
+    Java [`Model`] object that this class instance wraps.
+
+    [`Model`]: https://doc.comsol.com/6.4/doc/com.comsol.help.comsol/api/com/comsol/model/Model.html
+    """
 
     ############
     # Internal #

--- a/mph/node.py
+++ b/mph/node.py
@@ -203,12 +203,14 @@ class Node:
     @property
     def java(self) -> JClass | None:
         """
-        Java object this node maps to, if any.
+        Java [`ModelNode`] object that this class instance wraps, if any.
 
         Note that this is a property, not an attribute. Internally, it is a
         function that performs a top-down search of the model tree in order to
         resolve the node reference. So it introduces a certain overhead every
         time it is accessed.
+
+        [`ModelNode`]: https://doc.comsol.com/6.4/doc/com.comsol.help.comsol/api/com/comsol/model/ModelNode.html
         """
         if self.is_root():
             return self.model.java


### PR DESCRIPTION
Cosmetic change. We just want an easy link to click instead of searching for the correct page. Also, the doc-string for `Client.java` had a copy-and-paste typo in it.