### PR TITLE
feat: map Linux ARM64 COMSOL architecture

### DIFF
--- a/mph/discovery.py
+++ b/mph/discovery.py
@@ -73,6 +73,13 @@ def detect_architecture() -> str:
     if system == 'Linux' and machine == 'x86_64' and bits == '64bit':
         log.debug('Platform architecture is 64-bit x86 Linux.')
         return 'glnxa64'
+    if (
+        system == 'Linux'
+        and machine in ('aarch64', 'arm64')
+        and bits == '64bit'
+    ):
+        log.debug('Platform architecture is 64-bit ARM Linux.')
+        return 'glnxarm64'
     if system == 'Darwin' and processor == 'i386' and bits == '64bit':
         log.debug('Platform architecture is 64-bit Intel macOS.')
         return 'maci64'


### PR DESCRIPTION
## Summary
- map Linux ARM64 platform strings (`aarch64`/`arm64`) to COMSOL's documented `glnxarm64` architecture folder
- keep existing Linux x86_64, macOS, and Windows mappings unchanged
- remove the synthetic architecture unit test after maintainer feedback; real platform validation is the important signal here

Refs #248.

## Validation
- `uv run --group test ruff check mph/discovery.py tests/test_discovery.py`
- `uv run --group test pytest tests/test_discovery.py::test_parse`
- `uv run tools/run_tests.py` attempted, but blocked in the `discovery` group because this macOS ARM64 test machine has no supported COMSOL installation available
- `git diff --check`

## Validation gap
I do not have access to a Linux ARM64 machine with COMSOL installed, so this PR should not be treated as proof that MPh can support that platform without maintenance risk. It is only the minimal architecture-folder mapping for someone with the target platform to validate with the full test suite.