### PR TITLE
fix: Handle parameter tables of DoubleRowMatrix type with more than two rows.

### DIFF
--- a/mph/node.py
+++ b/mph/node.py
@@ -856,14 +856,8 @@ def get(
         value = java.getDoubleMatrix(name)
         if len(value) == 0:
             rows = []
-        elif len(value) == 1:
-            rows = [array(value[0])]
-        elif len(value) == 2:
-            rows = [array(value[0]), array(value[1])]
         else:
-            error = 'Cannot convert double-row matrix with more than two rows.'
-            log.error(error)
-            raise TypeError(error)
+            rows = [array(row) for row in value]
         return array(rows, dtype=object)
     elif datatype == 'File':
         return Path(str(java.getString(name)))


### PR DESCRIPTION
The handling of ```row matrices``` of type ```double``` (```DoubleRowMatrix```)  was modified.
Now it is possible to work with ```n``` rows, (instead of only 0, 1, 2). This can be helpful for reading back parameter tables with more than two rows (e.g. in a parametric sweeps).

Related issue: https://github.com/MPh-py/MPh/issues/255.